### PR TITLE
Implementação do ON_SUCCESS e ON_EXCEPTION

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,69 @@ Se o handler lançar alguma exception, a mensagem é automaticamente devolvida p
 Se o handler rodar sem erros, a mensagem é automaticamente confirmada (ack).
 
 
+## Rejeitando uma mensagem e não colocando-a de volta na fila
+
+Opcionalmente, caso seja necessário rejeitar uma mensagem e ao mesmo tempo **não** devolver essa mensagem pra fila,
+podemos chamar `message.reject(requeue=False)`. O valor default do `requeue` é `True`.
+
+## Configurações de ação padrão em caso de sucesso e exception
+
+É possível escolher o que o asynworker fará com as mensagens em caso de sucesso (handler executa sel lançar exceção)
+ou em caso de falha (handler lança uma exception não tratada).
+
+As opções são: Events.ON_SUCCESS e Events.ON_EXCEPTION. Ambas são passadas a cada rota de consumo registrada, ex:
+
+```python
+from asynworker.options import Events, Options
+
+@app.route(["queue1", "queue2"], options={
+                                  Events.ON_SUCCESS: Options.ACK,
+                                  Events.ON_EXCEPTION: Options.REJECT,
+                                  })
+async def handler(messages):
+    ...
+```
+
+Nesse caso, se o handler rodar com sucesso, todas as mensagem soferão `ACK`. Caso uma exceção não tratada seja capturada
+pelo asyncworker todas as mensagens sofrerão `REJECT`.
+
+### Opções possíveis
+
+ - `Options.ACK`: Confirma a mensagem para o RabbitMQ
+ - `Options.REJECT`: Rejeita a mensagem e **não devolve para a fila de origem**
+ - `Options.REQUEUE`: Rejeita a mensagem e **devolve** para a fila de origem.
+
+### Sobrescrevendo a ação padrão apenas para algumas mensagens
+
+É possível escolher uma ação diferente da padrão para qualquer mensagem do bulk que foi entregue ao handler. Para isso
+basta chamar um dos métodos do objeto `RabbitMQMessage`. São eles:
+
+ - `.accept()`: Marca a mensagem para ser confirmada para o RabbitMQ
+ - `.reject(requeue=False)`: Marca a mensagem para ser rejeitada e **não devolvida** para a fila de origem
+ - `.reject(requeue=True)`: Marca a mensagem para ser rejeitada e **devolvida** para a fila de origem
+
+O valor default para o `.reject()` é `requeue=True`.
+
+## Escolhendo o tamanho do BULK que será usado no consumo das fila
+
+Para conseguir receber mais de uma mensagem de uma vez, para poderem ser processadas em lote, podemos fazer o seguinte:
+
+```python
+from asyncworker import App
+from asyncworker.options import Options
+
+app = App(host="127.0.0.1", user="guest", password="guest", prefetch_count=256)
+
+@app.route(["asgard/counts", "asgard/counts/errors"], vhost="fluentd", options={Options.BULK_SIZE: 1000})
+async def drain_handler(messages):
+    for m in messages:
+      logger.info(message.body)
+
+```
+
 ## Atualizando o async-worker no seu projeto
 
-### 0.1.0 para 0.2.0
+### 0.1.x 0.2.0
 
 Na versão `0.2.0` criamos a possibilidade de receber mensagens em lote. E a partir dessa versão
 a assinatura do handler mudo para:
@@ -68,29 +128,6 @@ from asyncworker import App
 app = App(host="127.0.0.1", user="guest", password="guest", prefetch_count=256)
 
 @app.route(["asgard/counts", "asgard/counts/errors"], vhost="fluentd")
-async def drain_handler(messages):
-    for m in messages:
-      logger.info(message.body)
-
-```
-
-
-## Rejeitando uma mensagem e não colocando-a de volta na fila
-
-Opcionalmente, caso seja necessário rejeitar uma mensagem e ao mesmo tempo **não** devolver essa mensagem pra fila,
-podemos chamar `message.reject(requeue=False)`. O valor default do `requeue` é `True`.
-
-## Escolhendo o tamanho do BULK que será usado no consumo das fila
-
-Para conseuir receber mais de uma mensagem de uma vez, para poderem ser processadas em lote, podemos fazer o seguinte:
-
-```python
-from asyncworker import App
-from asyncworker.options import Options
-
-app = App(host="127.0.0.1", user="guest", password="guest", prefetch_count=256)
-
-@app.route(["asgard/counts", "asgard/counts/errors"], vhost="fluentd", options={Options.BULK_SIZE: 1000})
 async def drain_handler(messages):
     for m in messages:
       logger.info(message.body)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ async def drain_handler(messages):
 
 ```
 
+Nota sobre BULK_SIZE: O valor do BULK_SIZE sempre é escolhido com a fórmula: `min(BULK_SIZE, PREFRETCH)`. Isso para evitar que o código fique em um deadlock, onde ao mesmo tempo que ele aguarda o bulk encher para poder pegar mais mensagens da fila, ele está aguardando o bulk esvaziar para pegar mais mensagens da fila.
+ 
 ## Atualizando o async-worker no seu projeto
 
 ### 0.1.x 0.2.0

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ ou em caso de falha (handler lança uma exception não tratada).
 As opções são: Events.ON_SUCCESS e Events.ON_EXCEPTION. Ambas são passadas a cada rota de consumo registrada, ex:
 
 ```python
-from asynworker.options import Events, Options
+from asynworker.options import Events, Actions
 
 @app.route(["queue1", "queue2"], options={
-                                  Events.ON_SUCCESS: Options.ACK,
-                                  Events.ON_EXCEPTION: Options.REJECT,
+                                  Events.ON_SUCCESS: Actions.ACK,
+                                  Events.ON_EXCEPTION: Actions.REJECT,
                                   })
 async def handler(messages):
     ...
@@ -57,9 +57,9 @@ pelo asyncworker todas as mensagens sofrerão `REJECT`.
 
 ### Opções possíveis
 
- - `Options.ACK`: Confirma a mensagem para o RabbitMQ
- - `Options.REJECT`: Rejeita a mensagem e **não devolve para a fila de origem**
- - `Options.REQUEUE`: Rejeita a mensagem e **devolve** para a fila de origem.
+ - `Actions.ACK`: Confirma a mensagem para o RabbitMQ
+ - `Actions.REJECT`: Rejeita a mensagem e **não devolve para a fila de origem**
+ - `Actions.REQUEUE`: Rejeita a mensagem e **devolve** para a fila de origem.
 
 ### Sobrescrevendo a ação padrão apenas para algumas mensagens
 

--- a/asyncworker/options.py
+++ b/asyncworker/options.py
@@ -4,6 +4,8 @@ from enum import Enum, auto
 class Options(Enum):
     BULK_SIZE = auto()
     BULK_FLUSH_INTERVAL = auto()
+
+class Actions(Enum):
     ACK = auto()
     REJECT = auto()
     REQUEUE = auto()
@@ -17,5 +19,5 @@ class Events(Enum):
 class Defaultvalues:
     BULK_SIZE = 1
     BULK_FLUSH_INTERVAL = 60
-    ON_SUCCESS = Options.ACK
-    ON_EXCEPTION = Options.REQUEUE
+    ON_SUCCESS = Actions.ACK
+    ON_EXCEPTION = Actions.REQUEUE

--- a/asyncworker/options.py
+++ b/asyncworker/options.py
@@ -1,11 +1,13 @@
 from enum import Enum, auto
 
+
 class Options(Enum):
     BULK_SIZE = auto()
     BULK_FLUSH_INTERVAL = auto()
     ACK = auto()
     REJECT = auto()
     REQUEUE = auto()
+
 
 class Events(Enum):
     ON_SUCCESS = auto()

--- a/asyncworker/options.py
+++ b/asyncworker/options.py
@@ -16,4 +16,4 @@ class Defaultvalues:
     BULK_SIZE = 1
     BULK_FLUSH_INTERVAL = 60
     ON_SUCCESS = Options.ACK
-    ON_EXCEPTION = Options.REJECT
+    ON_EXCEPTION = Options.REQUEUE

--- a/asyncworker/rabbitmq/message.py
+++ b/asyncworker/rabbitmq/message.py
@@ -1,13 +1,13 @@
 from easyqueue.async import AsyncQueue
-from asyncworker.options import Options
+from asyncworker.options import Actions
 
 
 class RabbitMQMessage:
     def __init__(self,
                  body,
                  delivery_tag,
-                 on_success=Options.ACK,
-                 on_exception=Options.REQUEUE):
+                 on_success=Actions.ACK,
+                 on_exception=Actions.REQUEUE):
         self.body = body
         self._delivery_tag = delivery_tag
         self._on_success_action = on_success
@@ -25,17 +25,17 @@ class RabbitMQMessage:
         self._on_exception_action = None
 
     def reject(self, requeue=True):
-        self.final_action = Options.REQUEUE if requeue else Options.REJECT
+        self.final_action = Actions.REQUEUE if requeue else Actions.REJECT
 
     def accept(self):
-        self.final_action = Options.ACK
+        self.final_action = Actions.ACK
 
-    async def _process_action(self, action: Options, queue: AsyncQueue):
-        if action == Options.REJECT:
+    async def _process_action(self, action: Actions, queue: AsyncQueue):
+        if action == Actions.REJECT:
             await queue.reject(delivery_tag=self._delivery_tag, requeue=False)
-        elif action == Options.REQUEUE:
+        elif action == Actions.REQUEUE:
             await queue.reject(delivery_tag=self._delivery_tag, requeue=True)
-        elif action == Options.ACK:
+        elif action == Actions.ACK:
             await queue.ack(delivery_tag=self._delivery_tag)
 
     async def process_success(self, queue: AsyncQueue):

--- a/asyncworker/rabbitmq/message.py
+++ b/asyncworker/rabbitmq/message.py
@@ -1,11 +1,13 @@
-
 from easyqueue.async import AsyncQueue
 from asyncworker.options import Options
 
 
 class RabbitMQMessage:
-
-    def __init__(self, body, delivery_tag, on_success=Options.ACK, on_exception=Options.REQUEUE):
+    def __init__(self,
+                 body,
+                 delivery_tag,
+                 on_success=Options.ACK,
+                 on_exception=Options.REQUEUE):
         self.body = body
         self._delivery_tag = delivery_tag
         self._on_success_action = on_success

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -27,7 +27,7 @@ class AppTest(asynctest.TestCase):
                 "bulk_size": 1024,
                 "bulk_flush_interval": 120,
                 Events.ON_SUCCESS: Options.ACK,
-                Events.ON_EXCEPTION: Options.REJECT,
+                Events.ON_EXCEPTION: Options.REQUEUE,
             }
         }
         self.assertEqual(expected_registry_entry, app.routes_registry[_handler])
@@ -132,7 +132,7 @@ class AppTest(asynctest.TestCase):
 
         self.assertIsNotNone(app.routes_registry)
         self.assertEqual(Options.ACK, app.routes_registry[_handler]['options'][Events.ON_SUCCESS])
-        self.assertEqual(Options.REJECT, app.routes_registry[_handler]['options'][Events.ON_EXCEPTION])
+        self.assertEqual(Options.REQUEUE, app.routes_registry[_handler]['options'][Events.ON_EXCEPTION])
 
     async def test_app_receives_queue_connection(self):
         app = App(host="127.0.0.1", user="guest", password="guest", prefetch_count=1024)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,7 +3,7 @@ import asyncio
 import asynctest
 
 from asyncworker import App
-from asyncworker.options import Options, Defaultvalues, Events
+from asyncworker.options import Options, Defaultvalues, Events, Actions
 
 class AppTest(asynctest.TestCase):
 
@@ -26,8 +26,8 @@ class AppTest(asynctest.TestCase):
                 "vhost": expected_vhost,
                 "bulk_size": 1024,
                 "bulk_flush_interval": 120,
-                Events.ON_SUCCESS: Options.ACK,
-                Events.ON_EXCEPTION: Options.REQUEUE,
+                Events.ON_SUCCESS: Actions.ACK,
+                Events.ON_EXCEPTION: Actions.REQUEUE,
             }
         }
         self.assertEqual(expected_registry_entry, app.routes_registry[_handler])
@@ -108,21 +108,21 @@ class AppTest(asynctest.TestCase):
 
     async def test_register_action_on_success(self):
         app = App(**self.connection_parameters)
-        @app.route(["my-queue"], options = {Events.ON_SUCCESS: Options.REJECT})
+        @app.route(["my-queue"], options = {Events.ON_SUCCESS: Actions.REJECT})
         async def _handler(message):
             return 42
 
         self.assertIsNotNone(app.routes_registry)
-        self.assertEqual(Options.REJECT, app.routes_registry[_handler]['options'][Events.ON_SUCCESS])
+        self.assertEqual(Actions.REJECT, app.routes_registry[_handler]['options'][Events.ON_SUCCESS])
 
     async def test_register_action_on_exception(self):
         app = App(**self.connection_parameters)
-        @app.route(["my-queue"], options = {Events.ON_EXCEPTION: Options.ACK})
+        @app.route(["my-queue"], options = {Events.ON_EXCEPTION: Actions.ACK})
         async def _handler(message):
             return 42
 
         self.assertIsNotNone(app.routes_registry)
-        self.assertEqual(Options.ACK, app.routes_registry[_handler]['options'][Events.ON_EXCEPTION])
+        self.assertEqual(Actions.ACK, app.routes_registry[_handler]['options'][Events.ON_EXCEPTION])
 
     async def test_test_register_default_actions(self):
         app = App(**self.connection_parameters)
@@ -131,8 +131,8 @@ class AppTest(asynctest.TestCase):
             return 42
 
         self.assertIsNotNone(app.routes_registry)
-        self.assertEqual(Options.ACK, app.routes_registry[_handler]['options'][Events.ON_SUCCESS])
-        self.assertEqual(Options.REQUEUE, app.routes_registry[_handler]['options'][Events.ON_EXCEPTION])
+        self.assertEqual(Actions.ACK, app.routes_registry[_handler]['options'][Events.ON_SUCCESS])
+        self.assertEqual(Actions.REQUEUE, app.routes_registry[_handler]['options'][Events.ON_EXCEPTION])
 
     async def test_app_receives_queue_connection(self):
         app = App(host="127.0.0.1", user="guest", password="guest", prefetch_count=1024)

--- a/tests/test_rabbitmq_message.py
+++ b/tests/test_rabbitmq_message.py
@@ -3,65 +3,219 @@ from asynctest.mock import CoroutineMock
 from asynctest import mock
 
 from asyncworker.rabbitmq import RabbitMQMessage
-
+from asyncworker.options import Options, Events
 
 class RabbitMQMessageTest(asynctest.TestCase):
 
-    def test_defaults_to_be_acked(self):
-        message = RabbitMQMessage({}, 10)
-        self.assertTrue(message._do_ack)
+    def setUp(self):
+        self.queue_mock = CoroutineMock(ack=CoroutineMock(), reject=CoroutineMock())
 
-    def test_mark_message_to_be_rejected_and_requeued(self):
-        message = RabbitMQMessage({}, 10)
-        message.reject()
-        self.assertFalse(message._do_ack)
-        self.assertTrue(message._requeue)
+    #def test_defaults_to_be_acked(self):
+    #    message = RabbitMQMessage({}, 10)
+    #    self.assertTrue(message._do_ack)
 
-    def test_mark_message_to_be_rejected_and_discarded(self):
-        message = RabbitMQMessage({}, 10)
+    #def test_mark_message_to_be_rejected_and_requeued(self):
+    #    message = RabbitMQMessage({}, 10)
+    #    message.reject()
+    #    self.assertFalse(message._do_ack)
+    #    self.assertTrue(message._requeue)
+
+    #def test_mark_message_to_be_rejected_and_discarded(self):
+    #    message = RabbitMQMessage({}, 10)
+    #    message.reject(requeue=False)
+    #    self.assertFalse(message._do_ack)
+    #    self.assertFalse(message._requeue)
+
+    #def test_mark_message_to_be_acked(self):
+    #    message = RabbitMQMessage({}, 10)
+    #    message._do_ack = False
+    #    message.accept()
+    #    self.assertTrue(message._do_ack)
+
+    #def test_initialize_with_body_and_delivery_tag(self):
+    #    expected_body = {"key": "value"}
+    #    message = RabbitMQMessage(body=expected_body, delivery_tag=42)
+    #    self.assertEqual(expected_body, message.body)
+    #    self.assertEqual(42, message._delivery_tag)
+
+    #async def test_process_message_to_be_rejected_and_discarded(self):
+    #    expected_body = {"key": "value"}
+    #    message = RabbitMQMessage(body=expected_body, delivery_tag=42)
+    #    queue_mock = CoroutineMock(ack=CoroutineMock(), reject=CoroutineMock())
+    #    message.reject(requeue=False)
+    #    await message.process(queue_mock)
+    #    self.assertEqual(0, queue_mock.ack.await_count)
+    #    self.assertEqual(1, queue_mock.reject.await_count)
+    #    self.assertEqual([mock.call(delivery_tag=42, requeue=False)], queue_mock.reject.await_args_list)
+
+    #async def test_process_message_to_be_acked(self):
+    #    expected_body = {"key": "value"}
+    #    message = RabbitMQMessage(body=expected_body, delivery_tag=42)
+    #    queue_mock = CoroutineMock(ack=CoroutineMock(), reject=CoroutineMock())
+    #    await message.process(queue_mock)
+    #    queue_mock.ack.assert_awaited_once_with(delivery_tag=42)
+    #    self.assertEqual(0, queue_mock.reject.await_count)
+
+    #async def test_process_message_to_be_rejected(self):
+    #    """
+    #    Sempre fazemos reject com requeue.
+    #    """
+    #    expected_body = {"key": "value"}
+    #    message = RabbitMQMessage(body=expected_body, delivery_tag=42)
+    #    message.reject()
+
+    #    queue_mock = CoroutineMock(ack=CoroutineMock(), reject=CoroutineMock())
+    #    await message.process(queue_mock)
+    #    queue_mock.reject.assert_awaited_once_with(delivery_tag=42, requeue=True)
+    #    self.assertEqual(0, queue_mock.ack.await_count)
+
+
+    async def test_process_success_default_action(self):
+        """
+        Default é ACK, caso não digamos nada
+        """
+        message = RabbitMQMessage(body={}, delivery_tag=10)
+
+        await message.process_success(self.queue_mock)
+        self.queue_mock.ack.assert_awaited_with(delivery_tag=10)
+        self.queue_mock.reject.assert_not_awaited()
+
+    async def test_process_success_action_ack(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.ACK)
+
+        await message.process_success(self.queue_mock)
+        self.queue_mock.ack.assert_awaited_with(delivery_tag=10)
+        self.queue_mock.reject.assert_not_awaited()
+
+    async def test_process_success_action_reject(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.REJECT)
+
+        await message.process_success(self.queue_mock)
+        self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=False)
+        self.queue_mock.ack.assert_not_awaited()
+
+    async def test_process_success_action_requeue(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.REQUEUE)
+
+        await message.process_success(self.queue_mock)
+        self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=True)
+        self.queue_mock.ack.assert_not_awaited()
+
+    async def test_process_success_from_ack_to_requeue(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.ACK)
+        message.reject(requeue=True)
+        await message.process_success(self.queue_mock)
+        self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=True)
+        self.queue_mock.ack.assert_not_awaited()
+
+    async def test_process_success_from_ack_to_reject(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.ACK)
         message.reject(requeue=False)
-        self.assertFalse(message._do_ack)
-        self.assertFalse(message._requeue)
+        await message.process_success(self.queue_mock)
+        self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=False)
+        self.queue_mock.ack.assert_not_awaited()
 
-    def test_mark_message_to_be_acked(self):
-        message = RabbitMQMessage({}, 10)
-        message._do_ack = False
+    async def test_process_success_from_reject_to_ack(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.REJECT)
         message.accept()
-        self.assertTrue(message._do_ack)
+        await message.process_success(self.queue_mock)
+        self.queue_mock.ack.assert_awaited_with(delivery_tag=10)
+        self.queue_mock.reject.assert_not_awaited()
 
-    def test_initialize_with_body_and_delivery_tag(self):
-        expected_body = {"key": "value"}
-        message = RabbitMQMessage(body=expected_body, delivery_tag=42)
-        self.assertEqual(expected_body, message.body)
-        self.assertEqual(42, message._delivery_tag)
+    async def test_process_success_from_reject_to_requeue(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.REJECT)
+        message.reject(requeue=True)
+        await message.process_success(self.queue_mock)
+        self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=True)
+        self.queue_mock.ack.assert_not_awaited()
 
-    async def test_process_message_to_be_rejected_and_discarded(self):
-        expected_body = {"key": "value"}
-        message = RabbitMQMessage(body=expected_body, delivery_tag=42)
-        queue_mock = CoroutineMock(ack=CoroutineMock(), reject=CoroutineMock())
+    async def test_process_success_from_requeue_to_ack(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.REQUEUE)
+        message.accept()
+        await message.process_success(self.queue_mock)
+        self.queue_mock.ack.assert_awaited_with(delivery_tag=10)
+        self.queue_mock.reject.assert_not_awaited()
+
+    async def test_process_success_from_requeue_to_reject(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.REQUEUE)
         message.reject(requeue=False)
-        await message.process(queue_mock)
-        self.assertEqual(0, queue_mock.ack.await_count)
-        self.assertEqual(1, queue_mock.reject.await_count)
-        self.assertEqual([mock.call(delivery_tag=42, requeue=False)], queue_mock.reject.await_args_list)
+        await message.process_success(self.queue_mock)
+        self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=False)
+        self.queue_mock.ack.assert_not_awaited()
 
-    async def test_process_message_to_be_acked(self):
-        expected_body = {"key": "value"}
-        message = RabbitMQMessage(body=expected_body, delivery_tag=42)
-        queue_mock = CoroutineMock(ack=CoroutineMock(), reject=CoroutineMock())
-        await message.process(queue_mock)
-        queue_mock.ack.assert_awaited_once_with(delivery_tag=42)
-        self.assertEqual(0, queue_mock.reject.await_count)
+    async def test_process_exception_default_action(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10)
 
-    async def test_process_message_to_be_rejected(self):
-        """
-        Sempre fazemos reject com requeue.
-        """
-        expected_body = {"key": "value"}
-        message = RabbitMQMessage(body=expected_body, delivery_tag=42)
-        message.reject()
+        await message.process_exception(self.queue_mock)
+        self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=True)
+        self.queue_mock.ack.assert_not_awaited()
 
-        queue_mock = CoroutineMock(ack=CoroutineMock(), reject=CoroutineMock())
-        await message.process(queue_mock)
-        queue_mock.reject.assert_awaited_once_with(delivery_tag=42, requeue=True)
-        self.assertEqual(0, queue_mock.ack.await_count)
+    async def test_process_exception_action_requeue(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.REQUEUE)
+
+        await message.process_exception(self.queue_mock)
+        self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=True)
+        self.queue_mock.ack.assert_not_awaited()
+
+    async def test_process_exception_action_ack(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.ACK)
+
+        await message.process_exception(self.queue_mock)
+        self.queue_mock.ack.assert_awaited_with(delivery_tag=10)
+        self.queue_mock.reject.assert_not_awaited()
+
+    async def test_process_exception_action_reject(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.REJECT)
+
+        await message.process_exception(self.queue_mock)
+        self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=False)
+        self.queue_mock.ack.assert_not_awaited()
+
+    async def test_process_exception_from_ack_to_requeue(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.ACK)
+        message.reject(requeue=True)
+
+        await message.process_exception(self.queue_mock)
+        self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=True)
+        self.queue_mock.ack.assert_not_awaited()
+
+    async def test_process_exception_from_ack_to_reject(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.ACK)
+        message.reject(requeue=False)
+
+        await message.process_exception(self.queue_mock)
+        self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=False)
+        self.queue_mock.ack.assert_not_awaited()
+
+    async def test_process_exception_from_reject_to_ack(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.REJECT)
+        message.accept()
+
+        await message.process_exception(self.queue_mock)
+        self.queue_mock.ack.assert_awaited_with(delivery_tag=10)
+        self.queue_mock.reject.assert_not_awaited()
+
+    async def test_process_exception_from_reject_to_requeue(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.REJECT)
+        message.reject(requeue=True)
+
+        await message.process_exception(self.queue_mock)
+        self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=True)
+        self.queue_mock.ack.assert_not_awaited()
+
+    async def test_process_exception_from_requeue_to_ack(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.REQUEUE)
+        message.accept()
+
+        await message.process_exception(self.queue_mock)
+        self.queue_mock.ack.assert_awaited_with(delivery_tag=10)
+        self.queue_mock.reject.assert_not_awaited()
+
+    async def test_process_exception_from_requeue_to_reject(self):
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.REQUEUE)
+        message.reject(requeue=False)
+
+        await message.process_exception(self.queue_mock)
+        self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=False)
+        self.queue_mock.ack.assert_not_awaited()
+

--- a/tests/test_rabbitmq_message.py
+++ b/tests/test_rabbitmq_message.py
@@ -10,66 +10,6 @@ class RabbitMQMessageTest(asynctest.TestCase):
     def setUp(self):
         self.queue_mock = CoroutineMock(ack=CoroutineMock(), reject=CoroutineMock())
 
-    #def test_defaults_to_be_acked(self):
-    #    message = RabbitMQMessage({}, 10)
-    #    self.assertTrue(message._do_ack)
-
-    #def test_mark_message_to_be_rejected_and_requeued(self):
-    #    message = RabbitMQMessage({}, 10)
-    #    message.reject()
-    #    self.assertFalse(message._do_ack)
-    #    self.assertTrue(message._requeue)
-
-    #def test_mark_message_to_be_rejected_and_discarded(self):
-    #    message = RabbitMQMessage({}, 10)
-    #    message.reject(requeue=False)
-    #    self.assertFalse(message._do_ack)
-    #    self.assertFalse(message._requeue)
-
-    #def test_mark_message_to_be_acked(self):
-    #    message = RabbitMQMessage({}, 10)
-    #    message._do_ack = False
-    #    message.accept()
-    #    self.assertTrue(message._do_ack)
-
-    #def test_initialize_with_body_and_delivery_tag(self):
-    #    expected_body = {"key": "value"}
-    #    message = RabbitMQMessage(body=expected_body, delivery_tag=42)
-    #    self.assertEqual(expected_body, message.body)
-    #    self.assertEqual(42, message._delivery_tag)
-
-    #async def test_process_message_to_be_rejected_and_discarded(self):
-    #    expected_body = {"key": "value"}
-    #    message = RabbitMQMessage(body=expected_body, delivery_tag=42)
-    #    queue_mock = CoroutineMock(ack=CoroutineMock(), reject=CoroutineMock())
-    #    message.reject(requeue=False)
-    #    await message.process(queue_mock)
-    #    self.assertEqual(0, queue_mock.ack.await_count)
-    #    self.assertEqual(1, queue_mock.reject.await_count)
-    #    self.assertEqual([mock.call(delivery_tag=42, requeue=False)], queue_mock.reject.await_args_list)
-
-    #async def test_process_message_to_be_acked(self):
-    #    expected_body = {"key": "value"}
-    #    message = RabbitMQMessage(body=expected_body, delivery_tag=42)
-    #    queue_mock = CoroutineMock(ack=CoroutineMock(), reject=CoroutineMock())
-    #    await message.process(queue_mock)
-    #    queue_mock.ack.assert_awaited_once_with(delivery_tag=42)
-    #    self.assertEqual(0, queue_mock.reject.await_count)
-
-    #async def test_process_message_to_be_rejected(self):
-    #    """
-    #    Sempre fazemos reject com requeue.
-    #    """
-    #    expected_body = {"key": "value"}
-    #    message = RabbitMQMessage(body=expected_body, delivery_tag=42)
-    #    message.reject()
-
-    #    queue_mock = CoroutineMock(ack=CoroutineMock(), reject=CoroutineMock())
-    #    await message.process(queue_mock)
-    #    queue_mock.reject.assert_awaited_once_with(delivery_tag=42, requeue=True)
-    #    self.assertEqual(0, queue_mock.ack.await_count)
-
-
     async def test_process_success_default_action(self):
         """
         Default é ACK, caso não digamos nada

--- a/tests/test_rabbitmq_message.py
+++ b/tests/test_rabbitmq_message.py
@@ -3,7 +3,7 @@ from asynctest.mock import CoroutineMock
 from asynctest import mock
 
 from asyncworker.rabbitmq import RabbitMQMessage
-from asyncworker.options import Options, Events
+from asyncworker.options import Events, Actions
 
 class RabbitMQMessageTest(asynctest.TestCase):
 
@@ -81,63 +81,63 @@ class RabbitMQMessageTest(asynctest.TestCase):
         self.queue_mock.reject.assert_not_awaited()
 
     async def test_process_success_action_ack(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.ACK)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Actions.ACK)
 
         await message.process_success(self.queue_mock)
         self.queue_mock.ack.assert_awaited_with(delivery_tag=10)
         self.queue_mock.reject.assert_not_awaited()
 
     async def test_process_success_action_reject(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.REJECT)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Actions.REJECT)
 
         await message.process_success(self.queue_mock)
         self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=False)
         self.queue_mock.ack.assert_not_awaited()
 
     async def test_process_success_action_requeue(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.REQUEUE)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Actions.REQUEUE)
 
         await message.process_success(self.queue_mock)
         self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=True)
         self.queue_mock.ack.assert_not_awaited()
 
     async def test_process_success_from_ack_to_requeue(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.ACK)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Actions.ACK)
         message.reject(requeue=True)
         await message.process_success(self.queue_mock)
         self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=True)
         self.queue_mock.ack.assert_not_awaited()
 
     async def test_process_success_from_ack_to_reject(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.ACK)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Actions.ACK)
         message.reject(requeue=False)
         await message.process_success(self.queue_mock)
         self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=False)
         self.queue_mock.ack.assert_not_awaited()
 
     async def test_process_success_from_reject_to_ack(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.REJECT)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Actions.REJECT)
         message.accept()
         await message.process_success(self.queue_mock)
         self.queue_mock.ack.assert_awaited_with(delivery_tag=10)
         self.queue_mock.reject.assert_not_awaited()
 
     async def test_process_success_from_reject_to_requeue(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.REJECT)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Actions.REJECT)
         message.reject(requeue=True)
         await message.process_success(self.queue_mock)
         self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=True)
         self.queue_mock.ack.assert_not_awaited()
 
     async def test_process_success_from_requeue_to_ack(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.REQUEUE)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Actions.REQUEUE)
         message.accept()
         await message.process_success(self.queue_mock)
         self.queue_mock.ack.assert_awaited_with(delivery_tag=10)
         self.queue_mock.reject.assert_not_awaited()
 
     async def test_process_success_from_requeue_to_reject(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Options.REQUEUE)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_success=Actions.REQUEUE)
         message.reject(requeue=False)
         await message.process_success(self.queue_mock)
         self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=False)
@@ -151,28 +151,28 @@ class RabbitMQMessageTest(asynctest.TestCase):
         self.queue_mock.ack.assert_not_awaited()
 
     async def test_process_exception_action_requeue(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.REQUEUE)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Actions.REQUEUE)
 
         await message.process_exception(self.queue_mock)
         self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=True)
         self.queue_mock.ack.assert_not_awaited()
 
     async def test_process_exception_action_ack(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.ACK)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Actions.ACK)
 
         await message.process_exception(self.queue_mock)
         self.queue_mock.ack.assert_awaited_with(delivery_tag=10)
         self.queue_mock.reject.assert_not_awaited()
 
     async def test_process_exception_action_reject(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.REJECT)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Actions.REJECT)
 
         await message.process_exception(self.queue_mock)
         self.queue_mock.reject.assert_awaited_with(delivery_tag=10, requeue=False)
         self.queue_mock.ack.assert_not_awaited()
 
     async def test_process_exception_from_ack_to_requeue(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.ACK)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Actions.ACK)
         message.reject(requeue=True)
 
         await message.process_exception(self.queue_mock)
@@ -180,7 +180,7 @@ class RabbitMQMessageTest(asynctest.TestCase):
         self.queue_mock.ack.assert_not_awaited()
 
     async def test_process_exception_from_ack_to_reject(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.ACK)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Actions.ACK)
         message.reject(requeue=False)
 
         await message.process_exception(self.queue_mock)
@@ -188,7 +188,7 @@ class RabbitMQMessageTest(asynctest.TestCase):
         self.queue_mock.ack.assert_not_awaited()
 
     async def test_process_exception_from_reject_to_ack(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.REJECT)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Actions.REJECT)
         message.accept()
 
         await message.process_exception(self.queue_mock)
@@ -196,7 +196,7 @@ class RabbitMQMessageTest(asynctest.TestCase):
         self.queue_mock.reject.assert_not_awaited()
 
     async def test_process_exception_from_reject_to_requeue(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.REJECT)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Actions.REJECT)
         message.reject(requeue=True)
 
         await message.process_exception(self.queue_mock)
@@ -204,7 +204,7 @@ class RabbitMQMessageTest(asynctest.TestCase):
         self.queue_mock.ack.assert_not_awaited()
 
     async def test_process_exception_from_requeue_to_ack(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.REQUEUE)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Actions.REQUEUE)
         message.accept()
 
         await message.process_exception(self.queue_mock)
@@ -212,7 +212,7 @@ class RabbitMQMessageTest(asynctest.TestCase):
         self.queue_mock.reject.assert_not_awaited()
 
     async def test_process_exception_from_requeue_to_reject(self):
-        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Options.REQUEUE)
+        message = RabbitMQMessage(body={}, delivery_tag=10, on_exception=Actions.REQUEUE)
         message.reject(requeue=False)
 
         await message.process_exception(self.queue_mock)


### PR DESCRIPTION
Aqui temos um problema, tem até teste falhando para demonstrar.

E é o seguinte:

A partir do momento em que temos "acão padrão" para `ON_SUCCESS` e `ON_EXCEPTION` não podemos mais, dentro do handler, escolher o que será feito com cada mensagem. Por exemplo, se a ação padrão na `ON_EXCEPTION` é `REJECT` (`.reject(requeue=False)`) e o handler chama `.reject(requeue=True)`,  essa ação feita pelo handler será **desfeita** pelo asyncworker, depois que o `handler` retornar.

Isso vale para qualquer valor de `ON_SUCCESS` e `ON_EXCEPTION`.

Se formos contornar isso fazendo com que a `Message` tenha uma flag que impeça que uma segunda ação mude uma anterior, ou seja, se eu chamei `.reject(requeue=True)` uma chamada futura a `.reject(requeue=False)` será `NOOP`. Isso também é um problema pois o próprio handler não pode "mudar de ideia", ou seja, mudar o estado de uma mensagem durante sua execução.

Precisamos pensar no que fazer em relação a essa implementação aqui...