### PR TITLE
#64 -  RoutesRegistry refactoring

### DIFF
--- a/asyncworker/consumer.py
+++ b/asyncworker/consumer.py
@@ -1,12 +1,13 @@
 import asyncio
 import traceback
-from typing import Type, Dict
+from typing import Type, Dict, Union
 
 from easyqueue import AsyncQueueConsumerDelegate, AsyncQueue
 from aioamqp.exceptions import AioamqpException
 
 from asyncworker import conf
 from asyncworker.options import Events
+from asyncworker.routes import AMQPRoute
 from .bucket import Bucket
 from .rabbitmq import RabbitMQMessage
 
@@ -14,7 +15,7 @@ from .rabbitmq import RabbitMQMessage
 class Consumer(AsyncQueueConsumerDelegate):
     def __init__(
         self,
-        route_info: Dict,
+        route_info: Union[Dict, AMQPRoute],
         host: str,
         username: str,
         password: str,
@@ -26,7 +27,7 @@ class Consumer(AsyncQueueConsumerDelegate):
         self._queue_name = route_info["routes"]
         self._route_options = route_info["options"]
         self.host = host
-        self.vhost = self._route_options.get("vhost", "/")
+        self.vhost = route_info.get("vhost", "/")
         if self.vhost != "/":
             self.vhost = self.vhost.lstrip("/")
         self.bucket = bucket_class(

--- a/asyncworker/options.py
+++ b/asyncworker/options.py
@@ -1,19 +1,27 @@
 from enum import Enum, auto
+from typing import List
 
 
-class Options(Enum):
+class AutoNameEnum(str, Enum):
+    def _generate_next_value_(
+        name: str, start: int, count: int, last_values: List[str]
+    ) -> str:
+        return name.lower()
+
+
+class Options(AutoNameEnum):
     BULK_SIZE = auto()
     BULK_FLUSH_INTERVAL = auto()
     MAX_CONCURRENCY = auto()
 
 
-class Actions(Enum):
+class Actions(AutoNameEnum):
     ACK = auto()
     REJECT = auto()
     REQUEUE = auto()
 
 
-class Events(Enum):
+class Events(AutoNameEnum):
     ON_SUCCESS = auto()
     ON_EXCEPTION = auto()
 
@@ -26,7 +34,7 @@ class DefaultValues:
     RUN_EVERY_MAX_CONCURRENCY = 1
 
 
-class RouteTypes(Enum):
+class RouteTypes(AutoNameEnum):
     AMQP_RABBITMQ = auto()
     SSE = auto()
     HTTP = auto()

--- a/asyncworker/routes.py
+++ b/asyncworker/routes.py
@@ -12,6 +12,7 @@ from typing import (
     Type,
 )
 
+from aiohttp.hdrs import METH_ALL
 from aiohttp.web_routedef import RouteDef
 from cached_property import cached_property
 from pydantic import BaseModel, validator
@@ -80,6 +81,13 @@ class Route(Model, abc.ABC):
 class HTTPRoute(Route):
     type: RouteTypes = RouteTypes.HTTP
     methods: List[str]
+
+    @validator("methods")
+    def validate_method(cls, v: str):
+        method = v.upper()
+        if method not in METH_ALL:
+            raise ValueError(f"'{v}' isn't a valid supported HTTP method.")
+        return method
 
     def aiohttp_routes(self) -> Iterable[RouteDef]:
         for route in self.routes:

--- a/asyncworker/routes.py
+++ b/asyncworker/routes.py
@@ -22,7 +22,7 @@ from asyncworker.options import DefaultValues, RouteTypes, Actions
 RouteHandler = Callable[[], Coroutine]
 
 
-class Model(BaseModel, Mapping, abc.ABC):
+class Model(BaseModel, abc.ABC):
     """
     An abstract pydantic BaseModel that also behaves like a Mapping
     """
@@ -51,7 +51,7 @@ class Model(BaseModel, Mapping, abc.ABC):
             return default
 
 
-class Route(Model):
+class Route(Model, abc.ABC):
     """
     An abstract Model that acts like a route factory
     """

--- a/asyncworker/routes.py
+++ b/asyncworker/routes.py
@@ -1,86 +1,145 @@
+import abc
 from collections import UserDict
-from typing import Callable, Coroutine, Dict, List, Any
+from typing import Callable, Coroutine, Dict, List, Any, Union, Iterable
 
+from aiohttp.web_routedef import RouteDef
 from cached_property import cached_property
+from pydantic import BaseModel, validator
 
 from asyncworker.conf import settings
-from asyncworker.options import DefaultValues, Events, Options, RouteTypes
+from asyncworker.options import DefaultValues, RouteTypes, Actions
 
 RouteHandler = Callable[[], Coroutine]
-Route = Dict[str, Any]
+
+
+class Model(BaseModel, abc.ABC):
+    def __getitem__(self, item):
+        try:
+            return self.__getattr__(item)
+        except AttributeError as e:
+            raise KeyError from e
+
+    def __eq__(self, other):
+        if isinstance(other, dict):
+            return self.dict() == other
+        return super(Model, self).__eq__(other)
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+
+class Route(Model, abc.ABC):
+    """
+    An abstract Model that acts like a route factory
+    """
+
+    type: RouteTypes
+    handler: Any
+    routes: List[str]
+    default_options: dict = {}
+
+    @staticmethod
+    def factory(data: Dict) -> "Route":
+        try:
+            type_ = data.pop("type")
+        except KeyError as e:
+            raise ValueError("Routes must have a type") from e
+
+        if type_ not in RouteTypes:
+            raise ValueError(f"'{type_}' is an invalid RouteType.")
+
+        if type_ == RouteTypes.HTTP:
+            return HTTPRoute(**data)
+        if type_ == RouteTypes.AMQP_RABBITMQ:
+            return AMQPRoute(**data)
+        if type_ == RouteTypes.SSE:
+            return SSERoute(**data)
+
+
+class HTTPRoute(Route):
+    type: RouteTypes = RouteTypes.HTTP
+    methods: List[str]
+
+    def aiohttp_routes(self) -> Iterable[RouteDef]:
+        for route in self.routes:
+            for method in self.methods:
+                kwargs = {"allow_head": False} if method == "GET" else {}
+                yield RouteDef(
+                    method=method,
+                    path=route,
+                    handler=self.handler,
+                    kwargs=kwargs,
+                )
+
+
+class _AMQPRouteOptions(Model):
+    bulk_size: int = DefaultValues.BULK_SIZE
+    bulk_flush_interval: int = DefaultValues.BULK_FLUSH_INTERVAL
+    on_success: Actions = DefaultValues.ON_SUCCESS
+    on_exception: Actions = DefaultValues.ON_EXCEPTION
+
+
+class AMQPRoute(Route):
+    type: RouteTypes = RouteTypes.AMQP_RABBITMQ
+    vhost: str = settings.AMQP_DEFAULT_VHOST
+    options: _AMQPRouteOptions
+
+
+class _SSERouteOptions(Model):
+    bulk_size: int = DefaultValues.BULK_SIZE
+    bulk_flush_interval: int = DefaultValues.BULK_FLUSH_INTERVAL
+    headers: Dict[str, str] = {}
+
+
+class SSERoute(Route):
+    type: RouteTypes = RouteTypes.SSE
+    headers: Dict[str, str] = {}
+    options: _SSERouteOptions = _SSERouteOptions()
+
+    @validator("options", pre=True, whole=True, always=True)
+    def add_default_headers(cls, v, values, **kwargs):
+        headers = {
+            **values.pop("headers", {}),
+            **values.pop("default_options", {}).get("headers", {}),
+        }
+        v["headers"] = headers
+
+        return v
 
 
 class RoutesRegistry(UserDict):
     @cached_property
-    def http_routes(self) -> List[Route]:
+    def http_routes(self) -> Iterable[RouteDef]:
         routes = []
         for handler, route in self.items():
-            if route["type"] is not RouteTypes.HTTP:
-                continue
-            for path in route["routes"]:
-                for method in route["methods"]:
-                    routes.append(
-                        {"method": method, "path": path, "handler": handler}
-                    )
+            if isinstance(route, HTTPRoute):
+                routes.extend(route.aiohttp_routes())
         return routes
 
     @cached_property
-    def amqp_routes(self) -> List[Dict]:
-        routes = []
-        for handler, route in self.items():
-            if route["type"] is not RouteTypes.AMQP_RABBITMQ:
-                continue
-            options = route["options"]
-            routes.append(
-                {
-                    "routes": route["routes"],
-                    "handler": handler,
-                    "options": {
-                        "vhost": route.get(
-                            "vhost", settings.AMQP_DEFAULT_VHOST
-                        ),
-                        "bulk_size": options.get(
-                            Options.BULK_SIZE, DefaultValues.BULK_SIZE
-                        ),
-                        "bulk_flush_interval": options.get(
-                            Options.BULK_FLUSH_INTERVAL,
-                            DefaultValues.BULK_FLUSH_INTERVAL,
-                        ),
-                        Events.ON_SUCCESS: options.get(
-                            Events.ON_SUCCESS, DefaultValues.ON_SUCCESS
-                        ),
-                        Events.ON_EXCEPTION: options.get(
-                            Events.ON_EXCEPTION, DefaultValues.ON_EXCEPTION
-                        ),
-                    },
-                }
-            )
-        return routes
+    def amqp_routes(self) -> Iterable[AMQPRoute]:
+        return tuple((r for r in self.values() if isinstance(r, AMQPRoute)))
 
     @cached_property
-    def sse_routes(self) -> List[Route]:
-        routes = []
-        for handler, route in self.items():
-            if route["type"] is not RouteTypes.SSE:
-                continue
+    def sse_routes(self) -> Iterable[SSERoute]:
+        return tuple((r for r in self.values() if isinstance(r, SSERoute)))
 
-            options = route["options"]
-            headers = route.pop("headers", {})
-            default_headers = route["default_options"].get("headers", {})
-            routes.append(
-                {
-                    "routes": route["routes"],
-                    "handler": handler,
-                    "options": {
-                        "bulk_size": options.get(
-                            Options.BULK_SIZE, DefaultValues.BULK_SIZE
-                        ),
-                        "bulk_flush_interval": options.get(
-                            Options.BULK_FLUSH_INTERVAL,
-                            DefaultValues.BULK_FLUSH_INTERVAL,
-                        ),
-                        "headers": {**headers, **default_headers},
-                    },
-                }
-            )
-        return routes
+    def __setitem__(self, key: RouteHandler, value: Union[Dict, Route]):
+        if not isinstance(value, Route):
+            route = Route.factory({"handler": key, **value})
+        else:
+            route = value
+        super(RoutesRegistry, self).__setitem__(key, route)
+
+    def add_route(self, route: Union[Dict, Route]) -> Route:
+        if not isinstance(route, Route):
+            route = Route.factory(route)
+
+        self[route.handler] = route
+        return route
+
+    def route_for(self, handler: RouteHandler) -> Route:
+        return self[handler]

--- a/asyncworker/routes.py
+++ b/asyncworker/routes.py
@@ -151,12 +151,8 @@ class RoutesRegistry(UserDict):
             route = value
         super(RoutesRegistry, self).__setitem__(key, route)
 
-    def add_route(self, route: Union[Dict, Route]) -> Route:
-        if not isinstance(route, Route):
-            route = Route.factory(route)
-
+    def add_route(self, route: Route) -> None:
         self[route.handler] = route
-        return route
 
     def route_for(self, handler: RouteHandler) -> Route:
         return self[handler]

--- a/asyncworker/routes.py
+++ b/asyncworker/routes.py
@@ -51,7 +51,7 @@ class Model(BaseModel, Mapping, abc.ABC):
             return default
 
 
-class Route(Model, abc.ABC):
+class Route(Model):
     """
     An abstract Model that acts like a route factory
     """

--- a/asyncworker/signals/handlers/http.py
+++ b/asyncworker/signals/handlers/http.py
@@ -13,7 +13,8 @@ class HTTPServer(SignalHandler):
 
         app[RouteTypes.HTTP]["app"] = http_app = web.Application()
         for route in routes:
-            http_app.router.add_route(**route)
+            for route_def in route.aiohttp_routes():
+                route_def.register(http_app.router)
 
         app[RouteTypes.HTTP]["runner"] = web.AppRunner(http_app)
         await app[RouteTypes.HTTP]["runner"].setup()

--- a/tests/rabbitmq/test_rabbitmq_app.py
+++ b/tests/rabbitmq/test_rabbitmq_app.py
@@ -38,17 +38,19 @@ class RabbitMQAppTest(asynctest.TestCase):
 
         self.assertIsNotNone(app.routes_registry)
         expected_registry_entry = {
+            "type": RouteTypes.AMQP_RABBITMQ,
             "routes": expected_routes,
             "handler": _handler,
+            "default_options": {},
+            "vhost": expected_vhost,
             "options": {
-                "vhost": expected_vhost,
                 "bulk_size": 1024,
                 "bulk_flush_interval": 120,
                 Events.ON_SUCCESS: Actions.ACK,
                 Events.ON_EXCEPTION: Actions.REQUEUE,
             },
         }
-        route = app.routes_registry.amqp_routes[0]
+        route = app.routes_registry.route_for(_handler)
         self.assertEqual(expected_registry_entry, route)
         self.assertEqual(42, await route["handler"](None))
 
@@ -88,7 +90,7 @@ class RabbitMQAppTest(asynctest.TestCase):
 
         self.assertIsNotNone(app.routes_registry)
         route = app.routes_registry.amqp_routes[0]
-        self.assertEqual(expected_vhost, route["options"]["vhost"])
+        self.assertEqual(expected_vhost, route["vhost"])
         self.assertEqual(42, await route["handler"](None))
 
     async def test_register_bulk_size(self):

--- a/tests/rabbitmq/test_rabbitmq_consumer.py
+++ b/tests/rabbitmq/test_rabbitmq_consumer.py
@@ -33,8 +33,8 @@ class ConsumerTest(asynctest.TestCase):
         self.one_route_fixture = {
             "routes": ["/asgard/counts/ok"],
             "handler": _handler,
+            "vhost": "/",
             "options": {
-                "vhost": "/",
                 "bulk_size": 1,
                 "bulk_flush_interval": 60,
                 Events.ON_SUCCESS: Actions.ACK,
@@ -92,7 +92,7 @@ class ConsumerTest(asynctest.TestCase):
         )
 
     def test_consumer_instantiate_async_queue_default_vhost(self):
-        del self.one_route_fixture["options"]["vhost"]
+        del self.one_route_fixture["vhost"]
         consumer = Consumer(self.one_route_fixture, *self.connection_parameters)
         connection_parameters = consumer.queue.connection_parameters
 
@@ -103,7 +103,7 @@ class ConsumerTest(asynctest.TestCase):
         self.assertEqual("guest", connection_parameters["password"])
 
     def test_consumer_instantiate_async_queue_other_vhost(self):
-        self.one_route_fixture["options"]["vhost"] = "fluentd"
+        self.one_route_fixture["vhost"] = "fluentd"
         consumer = Consumer(self.one_route_fixture, *self.connection_parameters)
         connection_parameters = consumer.queue.connection_parameters
 
@@ -111,7 +111,7 @@ class ConsumerTest(asynctest.TestCase):
         self.assertEqual("fluentd", connection_parameters["virtualhost"])
 
     def test_consumer_instantiate_async_queue_other_vhost_strip_slash(self):
-        self.one_route_fixture["options"]["vhost"] = "/fluentd"
+        self.one_route_fixture["vhost"] = "/fluentd"
         consumer = Consumer(self.one_route_fixture, *self.connection_parameters)
         connection_parameters = consumer.queue.connection_parameters
 
@@ -119,7 +119,7 @@ class ConsumerTest(asynctest.TestCase):
         self.assertEqual("fluentd", connection_parameters["virtualhost"])
 
     def test_consumer_instantiate_async_queue_prefetch_count(self):
-        self.one_route_fixture["options"]["vhost"] = "/fluentd"
+        self.one_route_fixture["vhost"] = "/fluentd"
         consumer = Consumer(self.one_route_fixture, *self.connection_parameters)
         connection_parameters = consumer.queue.connection_parameters
 

--- a/tests/sse/test_sse_app.py
+++ b/tests/sse/test_sse_app.py
@@ -42,6 +42,7 @@ class AppTest(asynctest.TestCase):
         routes = app.routes_registry.sse_routes
         self.assertIsNotNone(routes)
         expected_registry_entry = {
+            "type": RouteTypes.SSE,
             "routes": expected_route,
             "handler": _handler,
             "options": {
@@ -71,6 +72,7 @@ class AppTest(asynctest.TestCase):
         routes = app.routes_registry.sse_routes
         self.assertIsNotNone(routes)
         expected_registry_entry = {
+            "type": RouteTypes.SSE,
             "routes": expected_route,
             "handler": _handler,
             "options": {

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,6 +6,7 @@ from signal import Signals
 
 from asyncworker import BaseApp
 from asyncworker.options import RouteTypes, DefaultValues, Options
+from asyncworker.routes import AMQPRoute
 from asyncworker.task_runners import ScheduledTaskRunner
 
 
@@ -74,19 +75,8 @@ class BaseAppTests(asynctest.TestCase):
             handler
         )
 
-        self.assertEqual(
-            self.app.routes_registry,
-            {
-                handler: {
-                    "type": RouteTypes.AMQP_RABBITMQ,
-                    "routes": ["route"],
-                    "handler": handler,
-                    "options": {},
-                    "default_options": self.app.default_route_options,
-                    "dog": "Xablau",
-                }
-            },
-        )
+        self.assertEqual(len(self.app.routes_registry), 1)
+        self.assertIsInstance(self.app.routes_registry[handler], AMQPRoute)
 
     async def test_run_on_startup_registers_a_coroutine_to_be_executed_on_startup(
         self

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,99 @@
+import unittest
+
+from asynctest import CoroutineMock
+
+from asyncworker import RouteTypes
+from asyncworker.routes import RoutesRegistry
+
+
+class RoutesRegistryTests(unittest.TestCase):
+    def setUp(self):
+        self.routes_registry = RoutesRegistry()
+
+    def test_it_registers_routes(self):
+        handler = CoroutineMock()
+
+        route_data = {
+            "type": RouteTypes.HTTP,
+            "routes": ["/"],
+            "methods": ["POST"],
+            "handler": handler,
+            "default_options": {},
+        }
+
+        new_route = self.routes_registry.add_route(route_data)
+
+        self.assertEqual(new_route, self.routes_registry.route_for(handler))
+
+    def test_route_for(self):
+        handler = CoroutineMock()
+
+        route_data = {
+            "type": RouteTypes.HTTP,
+            "routes": ["/"],
+            "methods": ["POST"],
+            "handler": handler,
+            "default_options": {},
+        }
+
+        self.routes_registry[handler] = route_data
+
+        self.assertEqual(self.routes_registry.route_for(handler), route_data)
+
+    def test_it_raise_an_error_if_the_route_has_an_invalid_type(self):
+        routes_registry = RoutesRegistry()
+
+        handler = CoroutineMock()
+        route_data = {
+            "type": "Xablau",
+            "routes": ["/"],
+            "methods": ["POST"],
+            "handler": handler,
+            "default_options": {},
+        }
+
+        with self.assertRaises(ValueError):
+            routes_registry[handler] = route_data
+
+    def test_it_raises_an_error_if_route_dict_dosnt_have_a_type(self):
+        handler = CoroutineMock()
+        route_data = {
+            "routes": ["/"],
+            "methods": ["POST"],
+            "handler": handler,
+            "default_options": {},
+        }
+
+        with self.assertRaises(ValueError):
+            self.routes_registry[handler] = route_data
+
+    def test_routes_are_subscriptables(self):
+        handler = CoroutineMock()
+        route_data = {
+            "type": RouteTypes.HTTP,
+            "routes": ["/"],
+            "methods": ["POST"],
+            "handler": handler,
+            "default_options": {},
+        }
+
+        new_route = self.routes_registry.add_route(route_data)
+
+        self.assertEqual(new_route["type"], RouteTypes.HTTP)
+        with self.assertRaises(KeyError):
+            _ = new_route["Invalid key"]
+
+    def test_routes_get_method(self):
+        handler = CoroutineMock()
+        route_data = {
+            "type": RouteTypes.HTTP,
+            "routes": ["/"],
+            "methods": ["POST"],
+            "handler": handler,
+            "default_options": {},
+        }
+
+        new_route = self.routes_registry.add_route(route_data)
+
+        self.assertEqual(new_route.get("type"), RouteTypes.HTTP)
+        self.assertEqual(new_route.get("Invalid key", "Default"), "Default")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -81,3 +81,31 @@ class RoutesRegistryTests(unittest.TestCase):
 
         self.assertEqual(route.get("type"), RouteTypes.HTTP)
         self.assertEqual(route.get("Invalid key", "Default"), "Default")
+
+
+class HTTPRoutesTests(unittest.TestCase):
+    def test_it_raise_an_error_for_invalid_methods(self):
+        with self.assertRaises(ValueError):
+            HTTPRoute(
+                methods=["POST", "Xablau"],
+                handler=CoroutineMock(),
+                routes=["/"],
+            )
+
+    def test_valid_http_methods(self):
+        route = HTTPRoute(
+            methods=[
+                "POST",
+                "GET",
+                "DELeTE",
+                "PUT",
+                "head",
+                "options",
+                "patch",
+                "TRACE",
+                "connect",
+            ],
+            handler=CoroutineMock(),
+            routes=["/"],
+        )
+        self.assertIsInstance(route, HTTPRoute)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -3,7 +3,7 @@ import unittest
 from asynctest import CoroutineMock
 
 from asyncworker import RouteTypes
-from asyncworker.routes import RoutesRegistry
+from asyncworker.routes import RoutesRegistry, HTTPRoute
 
 
 class RoutesRegistryTests(unittest.TestCase):
@@ -13,32 +13,24 @@ class RoutesRegistryTests(unittest.TestCase):
     def test_it_registers_routes(self):
         handler = CoroutineMock()
 
-        route_data = {
-            "type": RouteTypes.HTTP,
-            "routes": ["/"],
-            "methods": ["POST"],
-            "handler": handler,
-            "default_options": {},
-        }
+        route = HTTPRoute(
+            routes=["/"], methods=["POST"], handler=handler, default_options={}
+        )
 
-        new_route = self.routes_registry.add_route(route_data)
+        self.routes_registry.add_route(route)
 
-        self.assertEqual(new_route, self.routes_registry.route_for(handler))
+        self.assertEqual(route, self.routes_registry.route_for(handler))
 
     def test_route_for(self):
         handler = CoroutineMock()
 
-        route_data = {
-            "type": RouteTypes.HTTP,
-            "routes": ["/"],
-            "methods": ["POST"],
-            "handler": handler,
-            "default_options": {},
-        }
+        route = HTTPRoute(
+            routes=["/"], methods=["POST"], handler=handler, default_options={}
+        )
 
-        self.routes_registry[handler] = route_data
+        self.routes_registry[handler] = route
 
-        self.assertEqual(self.routes_registry.route_for(handler), route_data)
+        self.assertEqual(self.routes_registry.route_for(handler), route)
 
     def test_it_raise_an_error_if_the_route_has_an_invalid_type(self):
         routes_registry = RoutesRegistry()
@@ -69,31 +61,23 @@ class RoutesRegistryTests(unittest.TestCase):
 
     def test_routes_are_subscriptables(self):
         handler = CoroutineMock()
-        route_data = {
-            "type": RouteTypes.HTTP,
-            "routes": ["/"],
-            "methods": ["POST"],
-            "handler": handler,
-            "default_options": {},
-        }
+        route = HTTPRoute(
+            routes=["/"], methods=["POST"], handler=handler, default_options={}
+        )
 
-        new_route = self.routes_registry.add_route(route_data)
+        self.routes_registry.add_route(route)
 
-        self.assertEqual(new_route["type"], RouteTypes.HTTP)
+        self.assertEqual(route["type"], RouteTypes.HTTP)
         with self.assertRaises(KeyError):
-            _ = new_route["Invalid key"]
+            _ = route["Invalid key"]
 
     def test_routes_get_method(self):
         handler = CoroutineMock()
-        route_data = {
-            "type": RouteTypes.HTTP,
-            "routes": ["/"],
-            "methods": ["POST"],
-            "handler": handler,
-            "default_options": {},
-        }
+        route = HTTPRoute(
+            routes=["/"], methods=["POST"], handler=handler, default_options={}
+        )
 
-        new_route = self.routes_registry.add_route(route_data)
+        self.routes_registry.add_route(route)
 
-        self.assertEqual(new_route.get("type"), RouteTypes.HTTP)
-        self.assertEqual(new_route.get("Invalid key", "Default"), "Default")
+        self.assertEqual(route.get("type"), RouteTypes.HTTP)
+        self.assertEqual(route.get("Invalid key", "Default"), "Default")


### PR DESCRIPTION
On the public API, nothing changes, so there's no need to update the docs.
Motivation: Before working on middlewares, I thought we needed the `RoutesRegistry` and the routing system to be more "solid" 
closes #64 
closes #83 
