### PR TITLE
Adicionando timeout para realizar flush no bucket após N segundos

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Por exemplo, se tivermos um `handler` que possui
 
 Nesse caso a `app` irá esperar o timeout do flush para liberar essas mensagens para o `handler`.
 
+Caso queria alterar o tempo default do timeout do flush basta definir env `ASYNCWORKER_FLUSH_TIMEOUT` com um número que representara os segundos em que a app irá esperar para realizar o flush
+
 # HTTP (0.6.0+)
 
 Atualmente, uma das formas mais comuns comunicação entre aplicações é HTTP,

--- a/README.md
+++ b/README.md
@@ -226,6 +226,17 @@ async def _handler(dat):
 
 Nesse exemplo, o `_handler` só será chamado quando o async-worker tiver, **já nas mãos**, 1000 itens. Os 1000 itens serão passados de uma única vez para o handler, em uma lista.
 
+#### Flush timeout
+
+Com o flush timeout a `app` não necessita ficar presa esperando o bucket encher para conseguir processar as mensagens.
+Após o tempo do `FLUSH_TIMEOUT`, que são 60 segundos por default, a `app` irá enviar todas as mensagens que já possui para o `_handler`.
+Por exemplo, se tivermos um `handler` que possui
+ - Um `BULK_SIZE` de 1.000
+ - As mensagens para esse handles são publicadas diariamente
+ - E o bucket desse handler ficou com 500 mensagens
+
+Nesse caso a `app` irá esperar o timeout do flush para liberar essas mensagens para o `handler`.
+
 # HTTP (0.6.0+)
 
 Atualmente, uma das formas mais comuns comunicação entre aplicações é HTTP,

--- a/asyncworker/bucket.py
+++ b/asyncworker/bucket.py
@@ -1,7 +1,5 @@
-from datetime import datetime, timedelta
-from typing import List, Any, TypeVar, Generic
-
-from asyncworker import conf
+from datetime import datetime
+from typing import List, TypeVar, Generic
 
 T = TypeVar("T")
 
@@ -19,11 +17,6 @@ class Bucket(Generic[T]):
 
     def is_empty(self) -> bool:
         return len(self._items) == 0
-
-    def is_time_to_flush(self) -> bool:
-        return not self.is_empty() and datetime.utcnow() - self.last_bucket_flush >= timedelta(
-            seconds=conf.settings.TIMEOUT_TO_FLUSH_IN_SEC
-        )
 
     def put(self, item: T):
         if self.is_full():

--- a/asyncworker/bucket.py
+++ b/asyncworker/bucket.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import List, TypeVar, Generic
 
 T = TypeVar("T")
@@ -10,7 +9,6 @@ class Bucket(Generic[T]):
         # fixme: Criar uma interface comum para as *Message
         # para substituir esse Any
         self._items: List[T] = []
-        self.last_bucket_flush: datetime = datetime.utcnow()
 
     def is_full(self) -> bool:
         return len(self._items) == self.size
@@ -25,7 +23,6 @@ class Bucket(Generic[T]):
         self._items.append(item)
 
     def pop_all(self) -> List[T]:
-        self.last_bucket_flush = datetime.utcnow()
         _r = self._items
         self._items = []
         return _r

--- a/asyncworker/conf.py
+++ b/asyncworker/conf.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
 
     HTTP_HOST: str = "127.0.0.1"
     HTTP_PORT: int = 8080
+    TIMEOUT_TO_FLUSH_IN_SEC: int = 10
 
     class Config:
         allow_mutation = False

--- a/asyncworker/conf.py
+++ b/asyncworker/conf.py
@@ -11,7 +11,8 @@ class Settings(BaseSettings):
 
     HTTP_HOST: str = "127.0.0.1"
     HTTP_PORT: int = 8080
-    TIMEOUT_TO_FLUSH_IN_SEC: int = 10
+
+    FLUSH_TIMEOUT: int = 60
 
     class Config:
         allow_mutation = False

--- a/asyncworker/consumer.py
+++ b/asyncworker/consumer.py
@@ -194,7 +194,7 @@ class Consumer(AsyncQueueConsumerDelegate):
 
                     if not self.clock_task:
                         self.clock_task = self._flush_clocked(self.queue)
-                        asyncio.create_task(self.clock_task)
+                        asyncio.get_event_loop().create_task(self.clock_task)
 
                 except Exception as e:
                     await conf.logger.error(

--- a/asyncworker/consumer.py
+++ b/asyncworker/consumer.py
@@ -91,7 +91,7 @@ class Consumer(AsyncQueueConsumerDelegate):
                 )
                 self.bucket.put(message)
 
-            if self.bucket.is_full():
+            if self.bucket.is_full() or self.bucket.is_time_to_flush():
                 all_messages = self.bucket.pop_all()
                 rv = await self._handler(all_messages)
                 await asyncio.gather(

--- a/asyncworker/consumer.py
+++ b/asyncworker/consumer.py
@@ -7,6 +7,7 @@ from aioamqp.exceptions import AioamqpException
 
 from asyncworker import conf
 from asyncworker.options import Events
+from asyncworker.time import ClockTicker
 from .bucket import Bucket
 from .rabbitmq import RabbitMQMessage
 
@@ -40,6 +41,8 @@ class Consumer(AsyncQueueConsumerDelegate):
             delegate=self,
             prefetch_count=prefetch_count,
         )
+        self.clock = ClockTicker(seconds=conf.settings.FLUSH_TIMEOUT)
+        self.clock_task = None
 
     @property
     def queue_name(self) -> str:
@@ -78,26 +81,40 @@ class Consumer(AsyncQueueConsumerDelegate):
         :type content: dict
         :type queue: AsyncQueue
         """
-        rv = None
-        all_messages = []
-        try:
+        if not self.bucket.is_full():
+            message = RabbitMQMessage(
+                body=content,
+                delivery_tag=delivery_tag,
+                on_success=self._route_options[Events.ON_SUCCESS],
+                on_exception=self._route_options[Events.ON_EXCEPTION],
+            )
+            self.bucket.put(message)
+        if self.bucket.is_full():
+            return await self._flush_bucket_if_needed(queue)
 
-            if not self.bucket.is_full():
-                message = RabbitMQMessage(
-                    body=content,
-                    delivery_tag=delivery_tag,
-                    on_success=self._route_options[Events.ON_SUCCESS],
-                    on_exception=self._route_options[Events.ON_EXCEPTION],
+    async def _flush_clocked(self, queue):
+        async for _ in self.clock:
+            try:
+                await self._flush_bucket_if_needed(queue)
+            except Exception as e:
+                await conf.logger.error(
+                    {
+                        "type": "flush-bucket-failed",
+                        "dest": self.host,
+                        "retry": True,
+                        "exc_traceback": traceback.format_exc(),
+                    }
                 )
-                self.bucket.put(message)
 
-            if self.bucket.is_full() or self.bucket.is_time_to_flush():
+    async def _flush_bucket_if_needed(self, queue):
+        try:
+            if not self.bucket.is_empty():
                 all_messages = self.bucket.pop_all()
                 rv = await self._handler(all_messages)
                 await asyncio.gather(
                     *(m.process_success(queue) for m in all_messages)
                 )
-            return rv
+                return rv
         except AioamqpException as aioamqpException:
             raise aioamqpException
         except Exception as e:
@@ -174,6 +191,11 @@ class Consumer(AsyncQueueConsumerDelegate):
                 try:
                     await self.queue.connect()
                     await self.consume_all_queues(self.queue)
+
+                    if not self.clock_task:
+                        self.clock_task = self._flush_clocked(self.queue)
+                        asyncio.create_task(self.clock_task)
+
                 except Exception as e:
                     await conf.logger.error(
                         {

--- a/asyncworker/time.py
+++ b/asyncworker/time.py
@@ -31,8 +31,6 @@ class ClockTicker(AsyncIterator):
         self._tick_event = asyncio.Event()
         self._running: Optional[bool] = None
         self._main_task: Optional[asyncio.Future] = None
-        self.started_at = self.now()
-        self._last_tick: Optional[int] = None
 
     def now(self) -> int:
         """
@@ -53,21 +51,12 @@ class ClockTicker(AsyncIterator):
         if not self._running:
             raise StopAsyncIteration
 
-        while not self._should_iter():
-            await self._tick_event.wait()
-
         self._tick_event.clear()
+        await self._tick_event.wait()
+
         i = self.current_iteration
         self.current_iteration += 1
         return i
-
-    def _should_iter(self) -> bool:
-        now = self.now()
-        is_valid_interval = (now - self.started_at) % self.seconds == 0
-        if self._last_tick != now and is_valid_interval:
-            self._last_tick = now
-            return True
-        return False
 
     async def _run(self) -> None:
         while self._running:

--- a/asyncworker/time.py
+++ b/asyncworker/time.py
@@ -34,9 +34,6 @@ class ClockTicker(AsyncIterator):
         self.started_at = self.now()
         self._last_tick: Optional[int] = None
 
-    def is_running(self) -> Optional[bool]:
-        return self._running
-
     def now(self) -> int:
         """
         Returns an integer corresponding to the current time in seconds since

--- a/asyncworker/time.py
+++ b/asyncworker/time.py
@@ -32,6 +32,10 @@ class ClockTicker(AsyncIterator):
         self._running: Optional[bool] = None
         self._main_task: Optional[asyncio.Future] = None
         self.started_at = self.now()
+        self._last_tick: Optional[int] = None
+
+    def is_running(self) -> Optional[bool]:
+        return self._running
 
     def now(self) -> int:
         """
@@ -61,7 +65,12 @@ class ClockTicker(AsyncIterator):
         return i
 
     def _should_iter(self) -> bool:
-        return (self.now() - self.started_at) % self.seconds == 0
+        now = self.now()
+        is_valid_interval = (now - self.started_at) % self.seconds == 0
+        if self._last_tick != now and is_valid_interval:
+            self._last_tick = now
+            return True
+        return False
 
     async def _run(self) -> None:
         while self._running:

--- a/asyncworker/time.py
+++ b/asyncworker/time.py
@@ -32,13 +32,6 @@ class ClockTicker(AsyncIterator):
         self._running: Optional[bool] = None
         self._main_task: Optional[asyncio.Future] = None
 
-    def now(self) -> int:
-        """
-        Returns an integer corresponding to the current time in seconds since
-        the Epoch
-        """
-        return int(time.time())
-
     def __aiter__(self) -> AsyncIterator:
         if self._running is not None:
             raise RuntimeError("Cannot reuse a clock instance.")

--- a/tests/rabbitmq/test_rabbitmq_consumer.py
+++ b/tests/rabbitmq/test_rabbitmq_consumer.py
@@ -662,7 +662,9 @@ class ConsumerTest(asynctest.TestCase):
 
         with asynctest.patch.object(
             consumer, "keep_runnig", side_effect=[True, False]
-        ) as keep_running_mock, asynctest.patch.object(consumer, 'clock_task', side_effect=[True, True]):
+        ) as keep_running_mock, asynctest.patch.object(
+            consumer, "clock_task", side_effect=[True, True]
+        ):
             await consumer.start()
 
         self.assertEqual(1, queue_mock.connect.await_count)
@@ -683,7 +685,9 @@ class ConsumerTest(asynctest.TestCase):
         consumer = Consumer(self.one_route_fixture, *self.connection_parameters)
         with unittest.mock.patch.object(
             consumer, "keep_runnig", side_effect=[True, True, False]
-        ), asynctest.patch.object(asyncio, "sleep"), asynctest.patch.object(consumer, 'clock_task', side_effect=[True, True]):
+        ), asynctest.patch.object(asyncio, "sleep"), asynctest.patch.object(
+            consumer, "clock_task", side_effect=[True, True]
+        ):
             is_connected_mock = mock.PropertyMock(
                 side_effect=[False, False, True]
             )
@@ -719,7 +723,11 @@ class ConsumerTest(asynctest.TestCase):
         consumer = Consumer(self.one_route_fixture, *self.connection_parameters)
         with unittest.mock.patch.object(
             consumer, "keep_runnig", side_effect=[True, True, True, False]
-        ), asynctest.patch.object(asyncio, "sleep") as sleep_mock, asynctest.patch.object(consumer, 'clock_task', side_effect=[True, True]):
+        ), asynctest.patch.object(
+            asyncio, "sleep"
+        ) as sleep_mock, asynctest.patch.object(
+            consumer, "clock_task", side_effect=[True, True]
+        ):
             is_connected_mock = mock.PropertyMock(
                 side_effect=[False, True, True, True]
             )

--- a/tests/rabbitmq/test_rabbitmq_consumer.py
+++ b/tests/rabbitmq/test_rabbitmq_consumer.py
@@ -764,7 +764,7 @@ class ConsumerTest(asynctest.TestCase):
         consumer = Consumer(self.one_route_fixture, *self.connection_parameters)
         with unittest.mock.patch.object(
             consumer, "keep_runnig", side_effect=[True, True, True, False]
-        ), mock.patch.object(asyncio, "sleep"):
+        ):
             is_connected_mock = mock.PropertyMock(
                 side_effect=[True, False, False]
             )

--- a/tests/rabbitmq/test_rabbitmq_consumer.py
+++ b/tests/rabbitmq/test_rabbitmq_consumer.py
@@ -570,7 +570,6 @@ class ConsumerTest(asynctest.TestCase):
         await consumer.clock.stop()
         await asyncio.sleep(0.1)
 
-
     async def test_on_message_handle_error_logs_exception(self):
         """
         Logamos a exception lançada pelo handler.

--- a/tests/rabbitmq/test_rabbitmq_consumer.py
+++ b/tests/rabbitmq/test_rabbitmq_consumer.py
@@ -762,7 +762,7 @@ class ConsumerTest(asynctest.TestCase):
             await consumer.start()
         # Realizando sleep para devolver o loop para o clock
         await asyncio.sleep(0.01)
-        self.assertFalse(consumer.clock.is_running())
+        self.assertIsNone(consumer.clock_task)
         await consumer.clock.stop()
 
     async def test_start_create_clock_flusher(self):
@@ -787,7 +787,7 @@ class ConsumerTest(asynctest.TestCase):
             await consumer.start()
         # Realizando sleep para devolver o loop para o clock
         await asyncio.sleep(0.01)
-        self.assertTrue(consumer.clock.is_running())
+        self.assertIsNotNone(consumer.clock_task)
         await consumer.clock.stop()
 
     async def test_start_dont_created_another_clock_when_restart(self):

--- a/tests/rabbitmq/test_rabbitmq_consumer.py
+++ b/tests/rabbitmq/test_rabbitmq_consumer.py
@@ -500,7 +500,7 @@ class ConsumerTest(asynctest.TestCase):
 
         self.loop.create_task(consumer._flush_clocked(queue_mock))
         # Realizando sleep para devolver o loop para o clock
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.1)
         self.assertEqual(1, handler_mock.await_count)
         handler_mock.assert_awaited_once_with(items)
 
@@ -533,7 +533,7 @@ class ConsumerTest(asynctest.TestCase):
 
         self.loop.create_task(consumer._flush_clocked(queue_mock))
         # Realizando sleep para devolver o loop para o clock
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.1)
         self.assertEqual(0, handler_mock.await_count)
 
     async def test_clock_flush_dont_stop_on_exception_in_flush_clocked(self):
@@ -568,6 +568,8 @@ class ConsumerTest(asynctest.TestCase):
         await asyncio.sleep(0.1)
         self.assertEqual(2, consumer.clock.current_iteration)
         await consumer.clock.stop()
+        await asyncio.sleep(0.1)
+
 
     async def test_on_message_handle_error_logs_exception(self):
         """
@@ -753,7 +755,7 @@ class ConsumerTest(asynctest.TestCase):
         consumer = Consumer(self.one_route_fixture, *self.connection_parameters)
         with unittest.mock.patch.object(
             consumer, "keep_runnig", side_effect=[True, True, True, False]
-        ), mock.patch.object(asyncio, "sleep"):
+        ):
             is_connected_mock = mock.PropertyMock(
                 side_effect=[True, False, True]
             )
@@ -766,9 +768,10 @@ class ConsumerTest(asynctest.TestCase):
 
             await consumer.start()
         # Realizando sleep para devolver o loop para o clock
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.1)
         self.assertIsNone(consumer.clock_task)
         await consumer.clock.stop()
+        await asyncio.sleep(0.1)
 
     async def test_start_create_clock_flusher(self):
         self.one_route_fixture["routes"] = [
@@ -778,7 +781,7 @@ class ConsumerTest(asynctest.TestCase):
         consumer = Consumer(self.one_route_fixture, *self.connection_parameters)
         with unittest.mock.patch.object(
             consumer, "keep_runnig", side_effect=[True, True, True, False]
-        ), mock.patch.object(asyncio, "sleep"):
+        ):
             is_connected_mock = mock.PropertyMock(
                 side_effect=[True, False, False]
             )
@@ -791,9 +794,10 @@ class ConsumerTest(asynctest.TestCase):
 
             await consumer.start()
         # Realizando sleep para devolver o loop para o clock
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.1)
         self.assertIsNotNone(consumer.clock_task)
         await consumer.clock.stop()
+        await asyncio.sleep(0.1)
 
     async def test_start_dont_created_another_clock_when_restart(self):
         self.one_route_fixture["routes"] = [
@@ -808,7 +812,7 @@ class ConsumerTest(asynctest.TestCase):
 
         with unittest.mock.patch.object(
             consumer, "keep_runnig", side_effect=[True, False, True, False]
-        ), mock.patch.object(asyncio, "sleep"):
+        ):
             is_connected_mock = mock.PropertyMock(side_effect=[False, False])
             type(queue_mock).is_connected = is_connected_mock
             consumer.queue = queue_mock
@@ -819,6 +823,7 @@ class ConsumerTest(asynctest.TestCase):
             await consumer.start()
 
         # Realizando sleep para devolver o loop para o clock
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.1)
         self.assertTrue(my_task is consumer.clock_task)
         await consumer.clock.stop()
+        await asyncio.sleep(0.1)

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -1,7 +1,4 @@
-from datetime import datetime
-
 import asynctest
-from freezegun import freeze_time
 
 from asyncworker.bucket import Bucket, BucketFullException
 
@@ -73,22 +70,3 @@ class BucketTest(asynctest.TestCase):
 
         bucket._items = []
         self.assertTrue(bucket.is_empty())
-
-    @freeze_time("2019-2-5 15:45:39")
-    def test_tells_if_is_time_to_flush_bucket(self):
-        bucket = Bucket(size=5)
-
-        bucket._items = []
-        bucket.last_bucket_flush = datetime(2019, 2, 5, 15, 45, 39)
-        self.assertFalse(bucket.is_time_to_flush())
-
-        bucket._items = [1, 3, 2]
-        self.assertFalse(bucket.is_time_to_flush())
-
-        bucket._items = [1, 3, 2]
-        bucket.last_bucket_flush = datetime(2019, 2, 5, 15, 44, 39)
-        self.assertTrue(bucket.is_time_to_flush())
-
-        bucket._items = []
-        bucket.last_bucket_flush = datetime(2019, 2, 5, 15, 44, 39)
-        self.assertFalse(bucket.is_time_to_flush())

--- a/tests/test_bucket.py
+++ b/tests/test_bucket.py
@@ -61,12 +61,13 @@ class BucketTest(asynctest.TestCase):
 
     def test_tells_if_bucket_is_empty(self):
         bucket = Bucket(size=1)
-        bucket._items = []
+        bucket.pop_all()
         self.assertTrue(bucket.is_empty())
 
         bucket = Bucket(size=10)
-        bucket._items = [1, 2, 3]
+        for i in range(3):
+            bucket.put(i)
         self.assertFalse(bucket.is_empty())
 
-        bucket._items = []
+        bucket.pop_all()
         self.assertTrue(bucket.is_empty())

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -40,6 +40,8 @@ class ClockTickerTests(asynctest.TestCase):
             clock = ClockTicker(seconds=2)
             self.assertTrue(clock._should_iter())
 
+            self.assertFalse(clock._should_iter())
+
             frozen_datetime.tick(delta=datetime.timedelta(seconds=2))
             self.assertTrue(clock._should_iter())
 


### PR DESCRIPTION
Hoje o async-worker trabalhar com buckets de N mensagens que permitem a possibilidade de trabalhar diretamente com esse conjunto de mensagens. Porém caso o bucket não fique cheio as mensagens ficarão travadas até que o bucket alcance esse o seu limite de mensagens.

Com essa modificação será possível fazer flush das mensagens após alguns segundos.