### PR TITLE
#60 - Generic App

### DIFF
--- a/asyncworker/__init__.py
+++ b/asyncworker/__init__.py
@@ -1,21 +1,7 @@
-from asyncworker.base import BaseApp
-from asyncworker.consumer import Consumer  # noqa: F401
+from asyncworker.app import App
 from asyncworker.options import (  # noqa: F401
     Options,
     DefaultValues,
     Events,
     RouteTypes,
 )
-from asyncworker.signals.handlers.http import HTTPServer
-from asyncworker.signals.handlers.rabbitmq import RabbitMQ
-
-
-class App(BaseApp):
-    handlers = (RabbitMQ(), HTTPServer())
-
-    def __init__(self, host, user, password, prefetch_count):
-        super(App, self).__init__()
-        self.host = host
-        self.user = user
-        self.password = password
-        self.prefetch_count = prefetch_count

--- a/asyncworker/app.py
+++ b/asyncworker/app.py
@@ -4,7 +4,8 @@ from collections import MutableMapping
 from typing import Iterable, Tuple, Callable, Coroutine, Dict, Optional
 
 from asyncworker.conf import logger
-from asyncworker.signals.handlers.base import SignalHandler
+from asyncworker.signals.handlers.http import HTTPServer
+from asyncworker.signals.handlers.rabbitmq import RabbitMQ
 from asyncworker.routes import RoutesRegistry
 from asyncworker.options import RouteTypes, Options, DefaultValues
 from asyncworker.signals.base import Signal, Freezable
@@ -12,8 +13,8 @@ from asyncworker.task_runners import ScheduledTaskRunner
 from asyncworker.utils import entrypoint
 
 
-class BaseApp(MutableMapping, Freezable):
-    handlers: Tuple[SignalHandler, ...]
+class App(MutableMapping, Freezable):
+    handlers = (RabbitMQ(), HTTPServer())
     shutdown_os_signals = (Signals.SIGINT, Signals.SIGTERM)
 
     def __init__(self) -> None:
@@ -114,13 +115,13 @@ class BaseApp(MutableMapping, Freezable):
 
         return wrapper
 
-    def run_on_startup(self, coro: Callable[["BaseApp"], Coroutine]) -> None:
+    def run_on_startup(self, coro: Callable[["App"], Coroutine]) -> None:
         """
         Registers a coroutine to be awaited for during app startup
         """
         self._on_startup.append(coro)
 
-    def run_on_shutdown(self, coro: Callable[["BaseApp"], Coroutine]) -> None:
+    def run_on_shutdown(self, coro: Callable[["App"], Coroutine]) -> None:
         """
         Registers a coroutine to be awaited for during app shutdown
         """

--- a/asyncworker/conf.py
+++ b/asyncworker/conf.py
@@ -8,6 +8,8 @@ class Settings(BaseSettings):
     LOGLEVEL: str = "ERROR"
 
     AMQP_DEFAULT_VHOST: str = "/"
+    AMQP_DEFAULT_PREFETCH_COUNT: int = 128
+    AMQP_DEFAULT_HEARTBEAT: int = 60
 
     HTTP_HOST: str = "127.0.0.1"
     HTTP_PORT: int = 8080

--- a/asyncworker/rabbitmq/connection.py
+++ b/asyncworker/rabbitmq/connection.py
@@ -1,6 +1,7 @@
 from collections import Mapping
-from typing import Dict, List, Union, Iterator, Any
+from typing import Dict, List, Union, Iterator, Any, Optional
 
+from asyncworker.options import RouteTypes
 from asyncworker.easyqueue.queue import JsonQueue
 
 from asyncworker.conf import settings
@@ -10,10 +11,23 @@ Message = Union[List, Dict]
 
 
 class AMQPConnection(Mapping):
-    def __init__(self, hostname: str, username: str, password: str) -> None:
+    route_type = RouteTypes.AMQP_RABBITMQ
+
+    def __init__(
+        self,
+        hostname: str,
+        username: str,
+        password: str,
+        prefetch: int = settings.AMQP_DEFAULT_PREFETCH_COUNT,
+        heartbeat: int = settings.AMQP_DEFAULT_HEARTBEAT,
+        name: Optional[str] = None,
+    ) -> None:
         self.hostname = hostname
         self.username = username
         self.password = password
+        self.name = name
+        self.prefetch = prefetch
+        self.heartbeat = heartbeat
         self.__connections: Dict[str, JsonQueue] = {}
 
     def __len__(self) -> int:

--- a/asyncworker/signals/handlers/rabbitmq.py
+++ b/asyncworker/signals/handlers/rabbitmq.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from asyncworker.consumer import Consumer
 from asyncworker.signals.handlers.base import SignalHandler
@@ -6,20 +6,32 @@ from asyncworker.rabbitmq.connection import AMQPConnection
 from asyncworker.options import RouteTypes
 
 if TYPE_CHECKING:  # pragma: no cover
-    from asyncworker import App  # noqa: F401
+    from asyncworker.app import App  # noqa: F401
 
 
 class RabbitMQ(SignalHandler):
     async def startup(self, app: "App"):
-        app[RouteTypes.AMQP_RABBITMQ] = {}
-        app[RouteTypes.AMQP_RABBITMQ]["connection"] = AMQPConnection(
-            hostname=app.host, username=app.user, password=app.password
-        )
         app[RouteTypes.AMQP_RABBITMQ]["consumers"] = []
+        connections: List[AMQPConnection] = app[RouteTypes.AMQP_RABBITMQ][
+            "connections"
+        ]
         for route_info in app.routes_registry.amqp_routes:
+            try:
+                connection = connections[0]
+            except IndexError as e:
+                raise ValueError(
+                    "Invalid route definition for App. You are trying to "
+                    "define a RouteType.AMQP_RABBITMQ without an "
+                    "AMQPConnection registered on App."
+                ) from e
+
             consumer = Consumer(
-                route_info, app.host, app.user, app.password, app.prefetch_count
+                route_info=route_info,
+                host=connection.hostname,
+                username=connection.username,
+                password=connection.password,
+                prefetch_count=connection.prefetch,
             )
             app[RouteTypes.AMQP_RABBITMQ]["consumers"].append(consumer)
-            app[RouteTypes.AMQP_RABBITMQ]["connection"].register(consumer.queue)
+            connection.register(consumer.queue)
             app.loop.create_task(consumer.start())

--- a/asyncworker/task_runners.py
+++ b/asyncworker/task_runners.py
@@ -2,7 +2,7 @@ import asyncio
 from typing import Callable, Coroutine, Set, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from asyncworker.base import BaseApp  # pragma: nocover
+    from asyncworker.app import App  # pragma: nocover
 from asyncworker.time import ClockTicker
 
 
@@ -10,8 +10,8 @@ class ScheduledTaskRunner:
     def __init__(
         self,
         seconds: int,
-        task: Callable[["BaseApp"], Coroutine],
-        app: "BaseApp",
+        task: Callable[["App"], Coroutine],
+        app: "App",
         max_concurrency: int,
     ) -> None:
         self.seconds = seconds
@@ -42,11 +42,11 @@ class ScheduledTaskRunner:
             self.task_is_done_event.set()
             self.running_tasks.remove(asyncio.Task.current_task())
 
-    async def start(self, app: "BaseApp") -> asyncio.Future:
+    async def start(self, app: "App") -> asyncio.Future:
         self._started = True
         return asyncio.ensure_future(self._run())
 
-    async def stop(self, app: "BaseApp") -> None:
+    async def stop(self, app: "App") -> None:
         await self.clock.stop()
         await asyncio.gather(*self.running_tasks)
 


### PR DESCRIPTION
Fui tentar fazer o #60 e #61 numa tacada só e comecei a bater em questões só relacionadas ao #61, então voltei atrás pro ponto desse draft. Abri pra que você possa me ajudar a validar se as mudanças  tão fazendo sentido enquanto eu refatoro os testes


## Questões ainda a serem resolvidas

 - [ ] Como vamos definir/resgatar quem é a conexão padrão? Como isso varia para cada um dos tipos de conexão?
 - [ ] Vamos definir um nome (string) para cada conexão? 
    - Será obrigatório?
    - Será global entre todos os tipo de conexão? Ou poderemos ter um nome `"bla"` para uma conection Rabbit e para uma Connection SSE?
 - [ ] Obrigar que pelo menos uma conextion seja passada `__init__(self, connection, *aditional_connections)`;
 - [ ] Como será a ligação entre uma Conection e seu SignalHandler. Vamos tentar **não** usar o enum `RouteTypes` pra isso, pelo menos por enquanto. Para evitar dependencia circular. Talvez dê para usar um valor simples, privado, mas que seja igual no SignalHandler e na Connection concreta (sub-classe de `asyncworker.BaseConnection`.

