### PR TITLE
Versão Pydantic atualizada para 0.30 em setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         "aioamqp==0.12.0",
         "aiologger>=0.4.0-rc1",
-        "pydantic==0.28",
+        "pydantic==0.30",
         "cached-property==1.5.1",
         "aiohttp==3.4.4",
     ],


### PR DESCRIPTION
Modificado: `setup.py`
- "pydantic==0.28" alterado para "pydantic==0.30".
- Atualização pras versões `1.0b1` e `1.0b2` requer testes e observação do comportamento do `async-worke`r. Alterações nas novas versões incluem reorganização no parsing de URLs, mudanças em defaults do `BaseSettings` e em como a classe lê variáveis de ambiente, alterações na classe `BaseModel` (modificações em dunder methods `__getattr__`, `__values__` e` __dict__`), entre outras.

Closes #134 